### PR TITLE
fix 'Poll for Releases action'

### DIFF
--- a/.github/workflows/push_results_github.sh
+++ b/.github/workflows/push_results_github.sh
@@ -5,7 +5,8 @@ echo "Switch to checkout path"
 cd  /tmp/gcloud_history/
 
 echo "Setup push token"
-git remote set-url origin https://${GITHUB_PUSH_TOKEN}@github.com/twistedpair/google-cloud-sdk.git
+git remote set-url origin https://twistedpair:${GITHUB_PUSH_TOKEN}@github.com/twistedpair/google-cloud-sdk.git
+git config pull.rebase false
 
 echo "Push tags and commits..."
 git pull origin master --verbose


### PR DESCRIPTION
Hello, thanks for sharing this amazing and useful project! 🙌 

Recently [Poll for Releases action](https://github.com/twistedpair/google-cloud-sdk/actions/workflows/check-for-releases.yml) fails continuously, so I tried to investigate. In my forked repo, I've found two problems:

1. `username` needs to be set in Git HTTPS URL, or `git push` reports [`could not read Password for 'https://***@github.com': No such device or address` error](https://github.com/twistedpair/google-cloud-sdk/actions/runs/7640004979/job/20814212619)
    - I'm not sure in which GitHub account the `secrets.MY_GITHUB_PUSH_TOKEN` was created, so I use `twistedpair` as username for now.
3. `git config pull.rebase` needs to be set, or `git push` reports [`You have divergent branches and need to specify how to reconcile them.` error](https://github.com/KengoTODA/google-cloud-sdk/actions/runs/7640108342/job/20814533554#step:4:16)

This PR suggests to fix them by updating a script. Please have a look when you have time.
Thanks in advance for checking this PR!